### PR TITLE
Add unit declarator to module declaration

### DIFF
--- a/lib/Acme/Addslashes.pm
+++ b/lib/Acme/Addslashes.pm
@@ -1,4 +1,4 @@
-module Acme::Addslashes;
+unit module Acme::Addslashes;
 sub addslashes(Cool $string is copy) is export {
     $string = ~$string;
     $string ~~ s:g/(.)/$0\c[COMBINING LONG SOLIDUS OVERLAY]/;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module` (unless the module is wrapped in a block).  Modules still using the
old blockless semicolon form will throw a warning.  This commit stops the
warning from appearing in the new Rakudo.
